### PR TITLE
initial commit of issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1question.md
+++ b/.github/ISSUE_TEMPLATE/1question.md
@@ -1,0 +1,11 @@
+---
+name: Question
+about: Seeking help or have a question about usage?
+labels: question
+---
+
+<!-- We can't debug your app for you, but you can ask questions and we will try to answer them.
+
+It is super important that you paste in samples of your code (please avoid screenshots of code)!
+Without seeing what your code looks like, we won't be able to help you very much.
+More is better when it comes to sharing code samples if you're having a problem. -->

--- a/.github/ISSUE_TEMPLATE/1question.md
+++ b/.github/ISSUE_TEMPLATE/1question.md
@@ -11,6 +11,6 @@ You can also ask a question in the Node.js Slack community's #express-js channel
 * Slack invite form: http://www.nodeslackers.com/invite
 * #express-js channel: https://node-js.slack.com/archives/C0L827VV4
 
-It is super important that you paste in samples of your code (please avoid screenshots of code)!
+It is super important that you paste in samples of your code (no screenshots of code, [use markdown](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks))!
 Without seeing what your code looks like, we won't be able to help you very much.
 More is better when it comes to sharing code samples if you're having a problem. -->

--- a/.github/ISSUE_TEMPLATE/1question.md
+++ b/.github/ISSUE_TEMPLATE/1question.md
@@ -6,6 +6,8 @@ labels: question
 
 <!-- We can't debug your app for you, but you can ask questions and we will try to answer them.
 
+You can also ask a question in the [Node.js Slack](http://www.nodeslackers.com/invite) community's #express channel.
+
 It is super important that you paste in samples of your code (please avoid screenshots of code)!
 Without seeing what your code looks like, we won't be able to help you very much.
 More is better when it comes to sharing code samples if you're having a problem. -->

--- a/.github/ISSUE_TEMPLATE/1question.md
+++ b/.github/ISSUE_TEMPLATE/1question.md
@@ -6,7 +6,10 @@ labels: question
 
 <!-- We can't debug your app for you, but you can ask questions and we will try to answer them.
 
-You can also ask a question in the [Node.js Slack](http://www.nodeslackers.com/invite) community's #express channel.
+You can also ask a question in the Node.js Slack community's #express-js channel:
+
+* Slack invite form: http://www.nodeslackers.com/invite
+* #express-js channel: https://node-js.slack.com/archives/C0L827VV4
 
 It is super important that you paste in samples of your code (please avoid screenshots of code)!
 Without seeing what your code looks like, we won't be able to help you very much.

--- a/.github/ISSUE_TEMPLATE/2bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2bug_report.md
@@ -1,0 +1,13 @@
+---
+name: Bug Report
+about: Have you found a bug?
+labels: bug
+---
+
+<!-- The process for bug fixing is:
+
+- We will first assess if the behavior is different from what should occur
+- Confirm the bug is reproducible
+- Discuss how to best fix the bug
+- Work towards a fix
+-->

--- a/.github/ISSUE_TEMPLATE/2bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Have you found a bug?
+about: Do you believe you have found a bug?
 labels: bug
 ---
 

--- a/.github/ISSUE_TEMPLATE/3other.md
+++ b/.github/ISSUE_TEMPLATE/3other.md
@@ -1,0 +1,4 @@
+---
+name: Other
+about: I have something that isn't a bug or a question
+---


### PR DESCRIPTION
This PR draft should land on something like a staging branch, once one exists.

It creates three issue templates, `bug` and `question` each apply the equivalent label. `other` is a potential catch all.

I will PR the `config.yml` separately.