### PR TITLE
Issue Template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Report
+    url: http://expressjs.com/en/resources/contributing.html#security-policies-and-procedures
+    about: Email security reports to the maintainer list serve


### PR DESCRIPTION
This draft PR introduces a `config.yml`. See Github [docs here](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser).

As is, this PR does two things:

* Forces users to choose from one of the available Issue templates (`blank_issues_enabled: false`)
* Creates a link to [Expressjs.com security policy](http://expressjs.com/en/resources/contributing.html#security-policies-and-procedures) section

Everything about this config is up for debate. Currently the linked page doesn't clearly state an email address, which is something we can address elsewhere.