### PR TITLE
feat: update issue and PR templates to include 'require-triage' label

### DIFF
--- a/.github/ISSUE_TEMPLATE/1question.md
+++ b/.github/ISSUE_TEMPLATE/1question.md
@@ -1,7 +1,7 @@
 ---
 name: Question
 about: Seeking help or have a question about usage?
-labels: question
+labels: ["question", "require-triage"]
 ---
 
 <!-- We can't debug your app for you, but you can ask questions and we will try to answer them.

--- a/.github/ISSUE_TEMPLATE/2bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Do you believe you have found a bug?
-labels: bug
+labels: ["bug", "require-triage"]
 ---
 
 <!-- The process for bug fixing is:

--- a/.github/ISSUE_TEMPLATE/3feature_request.md
+++ b/.github/ISSUE_TEMPLATE/3feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Do you want to make a feature request?
-labels: ideas
+labels: ["ideas", "require-triage"]
 ---
 
 <!-- Please provide as much detailed information about your request as you can, specifically:

--- a/.github/ISSUE_TEMPLATE/4documentation.yml
+++ b/.github/ISSUE_TEMPLATE/4documentation.yml
@@ -1,6 +1,6 @@
 name: Documentation issue
 description: Report a possible issue in the documentation
-labels: doc
+labels: ["doc", "require-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/5other.md
+++ b/.github/ISSUE_TEMPLATE/5other.md
@@ -1,4 +1,5 @@
 ---
 name: Other
 about: I have something that isn't a bug or a question
+labels: require-triage
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+---
+labels: require-triage
+---
+
 <!--
 Thank you for your pull request. Please provide a description and 
 note the Certificate of Origin below. 


### PR DESCRIPTION
So that the label is added automatically instead of doing it manually.