### PR TITLE
docs: update contributing guide to enhance structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ Use the `master` branch for bug fixes or minor work that is intended for the
 current release stream.
 
 Use the correspondingly named branch, e.g. `6.x`, for anything intended for
-a future release of paquete.
+a future release of package.
 
 ### Granular PRs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to Express Ecosystem
 
 Thank you for your interest in contributing to the Express ecosystem! This document outlines
-how you can contribute to the Express project, including reporting issues, submitting code,
-and participating in discussions.
+how you can contribute to the Express project, including reporting issues, submitting pull requests,
+and participating in discussions and more.
 
 Express has a open governance model. For information about the governance of the Express project,
 see the [GOVERNANCE.md](https://github.com/expressjs/discussions/blob/HEAD/docs/GOVERNANCE.md)
@@ -14,6 +14,9 @@ Everyone who participates in this project, either as a user or a contributor, is
 to follow the project [Code of Conduct](https://github.com/expressjs/.github/blob/HEAD/CODE_OF_CONDUCT.md).
 
 ## Issues
+
+Submitting a pull request is not the only way to contribute to the Express project.
+You can also help by reporting issues, providing feedback, and participating in discussions.
 
 ### Reporting New Issues
 
@@ -68,19 +71,20 @@ If you post a question and do not outline the above items or make it easy for
 us to understand and reproduce your issue, it will be closed.
 
 If your question meets all of the above requirements but you do not believe it needs to be looked at
-by the maintainers (for example, if you are just looking for community input) please open it as a discussion
+by the maintainers (for example, if you are just looking for community input), please open it as a discussion
 topic instead of an issue. If you are unsure and open an issue, we may move it to discussions if we triage
 them and decide they do not need high visibility or maintainer input.
 
-### Resolving existing issues
+### Triaging Existing Issues
 
 You can help by contributing to issues that need attention.
 Check out this [guide](https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md)
 to learn more about the triage process.
 
-### Website Issues
+### Website and Documentation Issues
 
-Open issues for the expressjs.com website in [https://github.com/expressjs/expressjs.com](https://github.com/expressjs/expressjs.com)
+If you find issues with the Express documentation or website, please report them in the
+[expressjs.com repository](https://github.com/expressjs/expressjs.com).
 
 ## Sending a Pull Request
 
@@ -133,17 +137,26 @@ In short, here’s how to contribute:
 
 1. Create an issue for the
    bug you want to fix or the feature that you want to add.
-2. Create your own fork on GitHub, then
-   checkout your fork.
-3. Write your code in your local copy. It's good practice to create a branch for
-   each new issue you work on, although not compulsory.
-4. To run the test suite, first install the dependencies by running `npm install`,
+2. [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) and clone the repository to your local machine.
+3. Create a separate branch for your changes. This is important to keep
+   your work organized and to avoid conflicts with the main branch.
+   You can do this with `git checkout -b my-feature-branch`.
+   Replace `my-feature-branch` with a descriptive name for your branch.
+4. Write your code in your local copy.
+5. To run the test suite, first install the dependencies by running `npm install`,
    then run `npm test`.
-5. Ensure your code is linted by running `npm run lint`, fix any issue you
+6. Ensure your code is linted by running `npm run lint`, fix any issue you
    see listed.
-6. If the tests pass, you can commit your changes to your fork and then create
+7. If the tests pass, you can commit your changes to your fork and then create
    a pull request from there. Make sure to reference your issue from the pull
    request comments by including the issue number e.g. `#123`.
+
+## More Resources
+
+- Triager Guide: <https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md>
+- Governance: <https://github.com/expressjs/discussions/blob/master/docs/GOVERNANCE.md>
+- Release Guide: <https://github.com/expressjs/discussions/blob/master/docs/contributing/release-process.md>
+- Slack: <https://slack-invite.openjsf.org/>
 
 ## Developer's Certificate of Origin 1.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,9 @@ Express has a open governance model. For information about the governance of the
 see the [GOVERNANCE.md](https://github.com/expressjs/discussions/blob/HEAD/docs/GOVERNANCE.md)
 document.
 
+> [!TIP]
+> For new contributors: Take a look at <https://github.com/firstcontributions/first-contributions> for helpful information on contributing
+
 ## Code of Conduct
 
 Everyone who participates in this project, either as a user or a contributor, is obliged
@@ -83,8 +86,17 @@ to learn more about the triage process.
 
 ### Website and Documentation Issues
 
-If you find issues with the Express documentation or website, please report them in the
-[expressjs.com repository](https://github.com/expressjs/expressjs.com).
+There are two main ways you can help improve Express documentation:
+
+- **Repository Documentation Issues:**  
+  
+   If you spot mistakes or areas for improvement in this repository’s documentation (such as guides, README content, or inline API docs), please open an issue here. Your feedback helps us keep our docs accurate and useful for everyone.
+
+- **Website Documentation Issues:**  
+
+   If you notice errors or have suggestions for the Express website—like problems in guides, API documentation, or other website content—please report them in the [`expressjs/expressjs.com` repository](https://github.com/expressjs/expressjs.com).
+
+We encourage you to participate! Whether you’re fixing a typo or suggesting a new guide, your contributions make a difference. Open an issue in the right place and help us make Express documentation better for the whole community.
 
 ## Sending a Pull Request
 
@@ -115,12 +127,9 @@ as it makes reviews harder, delays merges, and complicates semantic titles
 
 ### Pull Request Reviews
 
-When a PR is not in draft, it's considered ready for review. Please don't manually
-tag anybody to request review. A maintainer will take a look when they're able and
-will tag whoever they think is best suited to review it.
+When a PR is not in draft, it is considered ready for review. You do not need to be a maintainer to review or comment on a PR, everyone is welcome to provide constructive feedback and suggestions! If you have time, please check open PRs and help improve the project. Do not manually tag anyone to request a review; a maintainer will assign reviewers as needed.
 
-PRs should have passing GitHub status checks before review is requested (unless there
-are explicit questions asked in the PR about any failures).
+Before requesting a review, make sure all GitHub checks are passing, unless you have specific questions about a failure.
 
 ### Requested Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,6 @@ Express has a open governance model. For information about the governance of the
 see the [GOVERNANCE.md](https://github.com/expressjs/discussions/blob/HEAD/docs/GOVERNANCE.md)
 document.
 
-> [!TIP]
-> For new contributors: Take a look at <https://github.com/firstcontributions/first-contributions> for helpful information on contributing
-
 ## Code of Conduct
 
 Everyone who participates in this project, either as a user or a contributor, is obliged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,135 @@
-# Express Collaborator Guide
+# Contributing to Express Ecosystem
 
-## Website Issues
+Thank you for your interest in contributing to the Express ecosystem! This document outlines
+how you can contribute to the Express project, including reporting issues, submitting code,
+and participating in discussions.
 
-Open issues for the expressjs.com website in https://github.com/expressjs/expressjs.com.
+Express has a open governance model. For information about the governance of the Express project,
+see the [GOVERNANCE.md](https://github.com/expressjs/discussions/blob/HEAD/docs/GOVERNANCE.md)
+document.
 
-For issues in other Express managed repos (everything in `expressjs`, `pillarjs` or `jshttp` other than `expressjs/express`), be sure to check their contributing guide and open issues and PRs in the appropriate repository.
+## Code of Conduct
 
-## PRs and Code contributions
+Everyone who participates in this project, either as a user or a contributor, is obliged
+to follow the project [Code of Conduct](https://github.com/expressjs/.github/blob/HEAD/CODE_OF_CONDUCT.md).
 
-* Tests must pass.
-* Follow the [JavaScript Standard Style](https://standardjs.com/) and `npm run lint`.
-* If you fix a bug, add a test.
+## Issues
 
-## Branches
+### Reporting New Issues
+
+Before opening a new issue, search existing and closed issues to avoid duplicates. If the solution
+provided in a previous issue doesn't work, please open a new issue with a clear description of the problem.
+
+Report issues for bugs, documentation improvements, or general enhancements. Please fill out all required
+fields in the relevant issue form.
+
+For issues in other express managed repos (everything in `expressjs`, `pillarjs` or `jshttp` other
+than `expressjs/express`), be sure to check their contributing guide and open issues and PRs in
+the appropriate repository.
+
+#### Providing a reproducible example
+
+A minimal, self-contained example helps others quickly understand and reproduce your issue.
+
+Steps:
+
+1. Isolate the Problem:
+   - Reduce your code to the smallest version that reproduces the issue.
+   - Remove unrelated code and dependencies.
+2. Make It Easy to Run:
+   - Avoid requiring special setup (e.g., CI tools, external services).
+   - Include clear instructions to run the example.
+3. Share It:
+   - Push the example to a new public GitHub repo.
+   - Share the link in your issue, describing the observed vs. expected behavior.
+
+Note: Issues without a reproducible example may be closed.
+
+#### Security Bugs
+
+If you believe you have found a security vulnerability in a package maintained by the Express project,
+please do not open a public issue or pull request. Instead, follow the instructions in the
+[Security Policy](https://github.com/expressjs/.github/blob/master/SECURITY.md)
+
+#### Issues which are questions
+
+We will typically close any vague issues or questions that are specific to some
+app you are writing. Please double check the docs and other references before
+being trigger happy with posting a question issue.
+
+Things that will help get your question issue looked at:
+
+- Full and runnable JS code.
+- Clear description of the problem or unexpected behavior.
+- Clear description of the expected result.
+- Steps you have taken to debug it yourself.
+
+If you post a question and do not outline the above items or make it easy for
+us to understand and reproduce your issue, it will be closed.
+
+If your question meets all of the above requirements but you do not believe it needs to be looked at
+by the maintainers (for example, if you are just looking for community input) please open it as a discussion
+topic instead of an issue. If you are unsure and open an issue, we may move it to discussions if we triage
+them and decide they do not need high visibility or maintainer input.
+
+### Resolving existing issues
+
+You can help by contributing to issues that need attention.
+Check out this [guide](https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md)
+to learn more about the triage process.
+
+### Website Issues
+
+Open issues for the expressjs.com website in [https://github.com/expressjs/expressjs.com](https://github.com/expressjs/expressjs.com)
+
+## Sending a Pull Request
+
+We actively welcome your Pull Requests! A couple of things to keep in mind before you submit:
+
+- If fixing an issue, ensure no one else has an open PR for it, unless you’re offering a different solution.
+Likewise, make sure to link your PR to the related Issue(s).
+- We will always try to accept the first viable PR that resolves the Issue.
+
+Prior to submitting your PR, please conduct the following pre-flight checks:
+
+- All tests must pass.
+- Code must follow [JavaScript Standard Style](https://standardjs.com/) and pass `npm run lint`
+- Bug fixes must include a test, PRs without tests will not be merged.
+
+### Branches
 
 Use the `master` branch for bug fixes or minor work that is intended for the
 current release stream.
 
 Use the correspondingly named branch, e.g. `6.x`, for anything intended for
-a future release of Express.
+a future release of paquete.
+
+### Granular PRs
+
+Keep pull requests focused on a single purpose. Don’t mix unrelated changes,
+as it makes reviews harder, delays merges, and complicates semantic titles
+
+### Pull Request Reviews
+
+When a PR is not in draft, it's considered ready for review. Please don't manually
+tag anybody to request review. A maintainer will take a look when they're able and
+will tag whoever they think is best suited to review it.
+
+PRs should have passing GitHub status checks before review is requested (unless there
+are explicit questions asked in the PR about any failures).
+
+### Requested Changes
+
+After a maintainer reviews your PR, they may request changes on it. Once you've made those changes,
+re-request review on GitHub.
+
+Please try not to force-push commits to PRs that have already been reviewed. Doing so makes it harder
+to review the changes. We squash merge all commits so there's no need to try to preserve Git history
+within a PR branch.
 
 ## Steps for contributing
+
+In short, here’s how to contribute:
 
 1. Create an issue for the
    bug you want to fix or the feature that you want to add.
@@ -30,32 +139,36 @@ a future release of Express.
    each new issue you work on, although not compulsory.
 4. To run the test suite, first install the dependencies by running `npm install`,
    then run `npm test`.
-5. Ensure your code is linted by running `npm run lint` -- fix any issue you
+5. Ensure your code is linted by running `npm run lint`, fix any issue you
    see listed.
 6. If the tests pass, you can commit your changes to your fork and then create
    a pull request from there. Make sure to reference your issue from the pull
    request comments by including the issue number e.g. `#123`.
 
-## Issues which are questions
+## Developer's Certificate of Origin 1.1
 
-We will typically close any vague issues or questions that are specific to some
-app you are writing. Please double check the docs and other references before
-being trigger happy with posting a question issue.
+```text
+By making a contribution to this project, I certify that:
 
-Things that will help get your question issue looked at:
+ (a) The contribution was created in whole or in part by me and I
+     have the right to submit it under the open source license
+     indicated in the file; or
 
-* Full and runnable JS code.
-* Clear description of the problem or unexpected behavior.
-* Clear description of the expected result.
-* Steps you have taken to debug it yourself.
+ (b) The contribution is based upon previous work that, to the best
+     of my knowledge, is covered under an appropriate open source
+     license and I have the right under that license to submit that
+     work with modifications, whether created in whole or in part
+     by me, under the same open source license (unless I am
+     permitted to submit under a different license), as indicated
+     in the file; or
 
-If you post a question and do not outline the above items or make it easy for
-us to understand and reproduce your issue, it will be closed.
+ (c) The contribution was provided directly to me by some other
+     person who certified (a), (b) or (c) and I have not modified
+     it.
 
-If your question meets all of the above requirements but you do not believe it needs to be looked at
-by the maintainers
-(for example, if you are just looking for community input) please open it as a discussion topic instead
-of an issue. If you
-are unsure and open an issue, we may move it to discussions if we triage them and decide they do
-not need high
-visibility or maintainer input. 
+ (d) I understand and agree that this project and the contribution
+     are public and that a record of the contribution (including all
+     personal information I submit with it, including my sign-off) is
+     maintained indefinitely and may be redistributed consistent with
+     this project or the open source license(s) involved.
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Note: Issues without a reproducible example may be closed.
 
 If you believe you have found a security vulnerability in a package maintained by the Express project,
 please do not open a public issue or pull request. Instead, follow the instructions in the
-[Security Policy](https://github.com/expressjs/.github/blob/master/SECURITY.md)
+[Security Policy](https://github.com/expressjs/.github/blob/HEAD/SECURITY.md)
 
 #### Issues which are questions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ as it makes reviews harder, delays merges, and complicates semantic titles
 
 ### Pull Request Reviews
 
-When a PR is not in draft, it is considered ready for review. You do not need to be a maintainer to review or comment on a PR, everyone is welcome to provide constructive feedback and suggestions! If you have time, please check open PRs and help improve the project. Do not manually tag anyone to request a review; a maintainer will assign reviewers as needed.
+When a PR is not in draft, it is considered ready for review. You do not need to be a maintainer to review or comment on a PR, everyone is welcome to provide constructive feedback and suggestions! If you have time, please check open PRs and help improve the project. **Do not manually tag anyone to request a review**; a maintainer will assign reviewers as needed.
 
 Before requesting a review, make sure all GitHub checks are passing, unless you have specific questions about a failure.
 
@@ -159,10 +159,10 @@ In short, here’s how to contribute:
 
 ## More Resources
 
-- Triager Guide: <https://github.com/expressjs/discussions/blob/master/docs/contributing/triager-guide.md>
-- Governance: <https://github.com/expressjs/discussions/blob/master/docs/GOVERNANCE.md>
-- Release Guide: <https://github.com/expressjs/discussions/blob/master/docs/contributing/release-process.md>
-- Slack: <https://slack-invite.openjsf.org/>
+- Triager Guide: <https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/triager-guide.md>
+- Governance: <https://github.com/expressjs/discussions/blob/HEAD/docs/GOVERNANCE.md>
+- Release Guide: <https://github.com/expressjs/discussions/blob/HEAD/docs/contributing/release-process.md>
+- Slack: <https://slack-invite.openjsf.org/> - We're in all channels that start with `express`.
 
 ## Developer's Certificate of Origin 1.1
 


### PR DESCRIPTION
I’m trying to expand the ways to contribute to the project.

cc: @expressjs/triagers @expressjs/express-tc 