### PR TITLE
docs: mention the Express Threat Model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,7 @@ project.
   * [Reporting a Bug or Security Vulnerability](#reporting-a-bug-or-security-vulnerability)
   * [Disclosure Policy](#disclosure-policy)
   * [Comments on this Policy](#comments-on-this-policy)
+  * [The Express Threat Model](#the-express-threat-model)
 
 ## Reporting a Bug or Security Vulnerability  
 
@@ -71,3 +72,7 @@ involving the following steps:
 
 If you have suggestions on how this process could be improved please submit a
 pull request.
+
+## The Express Threat Model
+
+The most updated version can be found [here](https://github.com/expressjs/security-wg/blob/main/docs/ThreatModel.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,9 @@ project.
 
 ## Reporting a Bug or Security Vulnerability  
 
+> [!IMPORTANT]
+> Before reporting a vulnerability, please review the [Express Threat Model](#the-express-threat-model) to check if the issue falls within Express's security scope.
+
 The Express team and community take all security vulnerabilities seriously. 
 Thank you for improving the security of Express and related projects. 
 We appreciate your efforts in responsible disclosure and will make every effort 
@@ -75,4 +78,8 @@ pull request.
 
 ## The Express Threat Model
 
-The most updated version can be found [here](https://github.com/expressjs/security-wg/blob/main/docs/ThreatModel.md)
+The Express threat model defines the boundaries of what the framework considers its security responsibility. It establishes which elements are trusted (such as the developer, the runtime environment, and application code) versus untrusted (such as data from network connections). Issues arising from trusted elements are considered out of scope, while Express is responsible for safely handling untrusted data.
+
+Many commonly reported concerns fall outside Express's security scope and are the responsibility of the application developer. Such as prototype pollution from unsanitized user input, misconfigured static file serving, or issues in third-party dependencies.
+
+For complete details, see the [Express Threat Model](https://github.com/expressjs/security-wg/blob/main/docs/ThreatModel.md).


### PR DESCRIPTION
Added a section on the Express Threat Model to the security policy.

Related: https://github.com/expressjs/express/pull/6570#pullrequestreview-2947482592

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
